### PR TITLE
Fix Python 3 print statement convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ In this project, we proposed a novel solution that can automatically convert the
 3. The total number of convolutional and fully connected layers in the network defined in Caffe .prototxt should be less than 15 layers
 
 ## Requirements:
+1. Install environment via conda.
+```
+conda env create -f environment_caffe.yml #Python3
+conda env create -f environment_caffe-python2.yml #Python2 if you want to run examples
+```
 
-1. To make sure you can use the quantized caffe model, please install [ristretto Caffe](https://github.com/pmgysel/caffe) instead of BVLC caffe following the instructions [here](http://caffe.berkeleyvision.org/installation.html), tested on rc3, and also the Python caffe by runing the `Make pycaffe` and `pip install -r requirements.txt` in caffe/python. Make sure that you have compiled the Python Caffe interface and that it is on your `PYTHONPATH`. Please also set the ACCDNN_ROOT.
+Optional: To make sure you can use the quantized caffe model, please install [ristretto Caffe](https://github.com/pmgysel/caffe) instead of BVLC caffe following the instructions [here](http://caffe.berkeleyvision.org/installation.html), tested on rc3, and also the Python caffe by runing the `Make pycaffe` and `pip install -r requirements.txt` in caffe/python. Make sure that you have compiled the Python Caffe interface and that it is on your `PYTHONPATH`. Please also set the ACCDNN_ROOT.
 ```
     export PYTHONPATH=path/to/caffe/python
     export ACCDNN_ROOT=path/to/AccDNN

--- a/freqency.py
+++ b/freqency.py
@@ -34,22 +34,22 @@ def get_clock_config (timing_file, output_file):
 
     mfile.close()
     if (not clk_acc_line) :
-        print "Can not find available timing information from file %s" % timing_file
+        print("Can not find available timing information from file %s" % timing_file)
         return False
 
     WNS = None
     TNS = None
     if (clk_acc_line):
-        print clk_acc_line
+        print(clk_acc_line)
         clock_data = clk_acc_line.split()
         if len(clock_data) > 10:
             WNS = float(clock_data[1])
             TNS = float(clock_data[2])
         else:
-            print "Can not find available timing information from file %s" % timing_file
+            print("Can not find available timing information from file %s" % timing_file)
             return False
 
-    print "WNS:%f; TNS:%f" % (WNS, TNS)
+    print("WNS:%f; TNS:%f" % (WNS, TNS))
     period = 5.0-WNS
     freqency = 1000.0/period
 
@@ -65,11 +65,11 @@ def get_clock_config (timing_file, output_file):
             pll_negedge_cnt = config [4]
             break
 
-    print "PIE works at frequency %fHz. Clock config is (%d,%d)" % (final_freqency, pll_posedge_cnt, pll_negedge_cnt)
+    print("PIE works at frequency %fHz. Clock config is (%d,%d)" % (final_freqency, pll_posedge_cnt, pll_negedge_cnt))
     mfile = open(output_file, 'w')
     mfile.write("%d,%d,1024" % (pll_posedge_cnt, pll_negedge_cnt))
     mfile.close()
-    print "PIE run-time config file is saved to %s" % output_file
+    print("PIE run-time config file is saved to %s" % output_file)
     return True
 
 if __name__ == '__main__':

--- a/layers/convolution.py
+++ b/layers/convolution.py
@@ -5,7 +5,8 @@ import math
 from util.math2 import is_power
 from util.resource import get_brams
 from settings import *
-import ConfigParser
+#import ConfigParser
+import configparser as ConfigParser
 import numpy as np
 
 class Convolution(Layer):
@@ -65,7 +66,7 @@ class Convolution(Layer):
             self.dsp_split = True
             # kpf should be even whe dsp_split is true
             self.kpf = max(2, self.kpf) 
-            print '%s:The dsp will be splited for two channels.'%(self.layer_name)
+            print('%s:The dsp will be splited for two channels.'%(self.layer_name))
             #if self.kpf % 2 != 0:
             #    raise Exception('%s:KPF should be even when dsp is splited.'%(self.layer_name))
 
@@ -146,7 +147,7 @@ class Convolution(Layer):
         cycle_per_dout = self.kernel_shape[0] * self.kernel_shape[1] * self.kernel_shape[2] / self.cpf
        
         if cycle_per_dout <= access_operator_delay:
-            print '%s: Too higher CPF, will insert a fifo before layer output.'%self.layer_name
+            print('%s: Too higher CPF, will insert a fifo before layer output.'%self.layer_name)
             self.insert_fifo = True
             self.fifo_depth = int(math.ceil(float(access_operator_delay + 1) / float(cycle_per_dout)))
 
@@ -178,15 +179,15 @@ class Convolution(Layer):
 
         # compute batch normalization parameters
         if self.bn:
-            print self.bn[1]
+            print(self.bn[1])
             bn_scale = self.bn[2] / np.sqrt(self.bn[1] + 1e-10)
             bn_bias = self.bn[3] - self.bn[0] * self.bn[2] / np.sqrt(self.bn[1] + 1e-10)
             #print bn_scale, bn_bias
             # search the best quantization for scale and bias
             self.bn_scale_dq = int(math.floor(math.log(1.0/np.max(np.abs(bn_scale))) / math.log(2.0))) + 15
             self.bn_bias_dq = int(math.floor(math.log(1.0/np.max(np.abs(bn_bias))) / math.log(2.0))) + 15
-            print 'Layer {}:\tSCALE_Q:{}, BIAS_Q:{}, SCALE_MAX:{}, BIAS:{}'\
-                .format(self.layer_name, self.bn_scale_dq, self.bn_bias_dq, np.max(np.abs(bn_scale)), np.max(np.abs(bn_bias)))
+            print('Layer {}:\tSCALE_Q:{}, BIAS_Q:{}, SCALE_MAX:{}, BIAS:{}'\
+                .format(self.layer_name, self.bn_scale_dq, self.bn_bias_dq, np.max(np.abs(bn_scale)), np.max(np.abs(bn_bias))))
             #normalize the bias Q to scale Q, in order to have a uniformed Q
             bn_bias = bn_bias * (2 ** self.bn_bias_dq) / (2 ** self.bn_scale_dq)
             bn_array = np.concatenate([bn_scale.reshape(-1, 1), bn_bias.reshape(-1, 1)], axis = 1)\

--- a/layers/innerproduct.py
+++ b/layers/innerproduct.py
@@ -7,13 +7,13 @@ class InnerProduct(Convolution):
         kernel_shape = tuple([params[0].shape[1], 1, 1])
         #reshape the matrix from 2-dim to 4-dim
         weights_shape = tuple([kernel_num, kernel_shape[0], kernel_shape[1], kernel_shape[2]])
-        print "Layer %s: Weights will be reshaped from %s to %s."%(layer_name, params[0].shape, weights_shape);
+        print("Layer %s: Weights will be reshaped from %s to %s."%(layer_name, params[0].shape, weights_shape))
         params[0] =  params[0].reshape(weights_shape)
 
         if input_shape[0] != kernel_shape[0]:
             input_shape_old = input_shape
             input_shape_new = tuple([input_shape[0] * input_shape[1] * input_shape[2], 1, 1])
-            print "Layer %s: Input data will be reshaped from %s to %s."%(layer_name, input_shape, input_shape_new)
+            print("Layer %s: Input data will be reshaped from %s to %s."%(layer_name, input_shape, input_shape_new))
             input_shape = input_shape_new
             #weights will do the permutation.
             params[0] = params[0].reshape(kernel_num, input_shape_old[0], input_shape_old[1], input_shape_old[2]) \

--- a/layers/pooling.py
+++ b/layers/pooling.py
@@ -75,7 +75,7 @@ class Pooling(Layer):
         cycle_per_dout = self.kernel_size * self.kernel_size
 
         if cycle_per_dout <= access_operator_delay:
-            print '%s: Too higher CPF, will insert a fifo before layer output.'%self.layer_name
+            print('%s: Too higher CPF, will insert a fifo before layer output.'%self.layer_name)
             self.insert_fifo = True
             self.fifo_depth = int(math.ceil(float(access_operator_delay + 1) / float(cycle_per_dout)))
 

--- a/service.py
+++ b/service.py
@@ -127,18 +127,18 @@ if __name__ == '__main__':
     weight_file = 'example/cifar10/cifar10_quick_iter_5000.caffemodel'
     # weight_file = '../models/alexnet-quantized/alexnet_A16C8F4_iter_2000.caffemodel'
     ret = check_prototxt(model_file)
-    print ret
+    print(ret)
     ret = check_weights(model_file, weight_file)
-    print ret
+    print(ret)
     acc_settings_json = json.dumps({'resource':{'dsp_num':270, 'ram18e_num':327, 'ddr_bandwidth':80000}, \
                                     'fpga_type':'xcku115-flva1517-2-e', \
                                     'ddr_data_width':256})
     ret = accdnn_profile(model_file, acc_settings_json)
-    print ret
+    print(ret)
     ret = accdnn_optimze(model_file, acc_settings_json, json.dumps(json.loads(ret).get('parameter')))
-    print ret
+    print(ret)
     ret = accdnn_codegen(model_file, weight_file, acc_settings_json, json.dumps(json.loads(ret).get('parameter')))
-    print ret
+    print(ret)
 
    
 

--- a/tools/activation_plot.py
+++ b/tools/activation_plot.py
@@ -14,7 +14,7 @@ def compare(real_file):
     for line in fp:
         data_list.append(float(line.strip()))
     real_array = np.array(data_list)
-    print real_array
+    print(real_array)
 
     plt.figure(1)
     plot2 = plt.plot(np.arange(len(real_array)), real_array, 'b')

--- a/tools/compare.py
+++ b/tools/compare.py
@@ -13,7 +13,7 @@ NUM_MAX = 2 ** (bits_per_element)
 NUM_MAX_HALF = 2 ** (bits_per_element - 1)
 
 def compare(sim_file, real_file, bits_per_element, height, stride=1, iteration=1):
-    print bits_per_element
+    print(bits_per_element)
     hex_num_per_element = bits_per_element / 4
     NUM_MAX = 2 ** (bits_per_element)
     NUM_MAX_HALF = 2 ** (bits_per_element - 1)    
@@ -36,7 +36,7 @@ def compare(sim_file, real_file, bits_per_element, height, stride=1, iteration=1
         lines_per_iteration = len_array / elements_per_line
     else:
         lines_per_iteration = len_array / elements_per_line + 1
-    print 'lines_per_iteration:', lines_per_iteration
+    print('lines_per_iteration:', lines_per_iteration)
     if len(line_list) < (iteration-1)*lines_per_iteration:
         raise Exception('Not enough data generated...')
     if len(line_list) < iteration*lines_per_iteration:
@@ -64,13 +64,13 @@ def compare(sim_file, real_file, bits_per_element, height, stride=1, iteration=1
     sim_array = np.array(data_list, dtype='float32')
     sim_array[np.where(sim_array >= NUM_MAX_HALF)] = sim_array[np.where(sim_array >= NUM_MAX_HALF)] - NUM_MAX
     
-    print sim_array
-    print real_array
+    print(sim_array)
+    print(real_array)
 
     if len(sim_array) == len(real_array):
         diff = sim_array - real_array
         error = np.sqrt((diff**2).sum() / ((real_array**2).sum()))
-        print 'Quantization error is %f'%(error)
+        print('Quantization error is %f'%(error))
 
     plt.figure(1)
     #plot1 = plt.plot(np.arange(len(sim_array)), diff, 'r')

--- a/tools/sim_data_gen.py
+++ b/tools/sim_data_gen.py
@@ -74,7 +74,7 @@ def sim_data_gen(model_file, pretrained_model, imagepath, batch_size, iteration)
             raise Exception ("Blob data dimension is not know.")
         module_inst = model_inst.get_inst_by_layer_name(k)
         if module_inst is None:
-            print '{} layer is not found.'.format(k)
+            print('{} layer is not found.'.format(k))
             # file_path_name = DUMP_BLOB_DATA_PATH + '/' + k + '.dat'
             # mat_dump_float(file_path_name, blob_data, 8,  1)
             continue

--- a/util/data.py
+++ b/util/data.py
@@ -70,7 +70,7 @@ def uint16_dump_hex_aligned(file_path_name, mat):
 
 def mat_dump_float(file_path_name, mat, dw, dq):
     if mat.ndim != 1:
-        print "Input mat dimension is not 1, will reshape to 1."
+        print("Input mat dimension is not 1, will reshape to 1.")
         mat = mat.reshape(-1)
     #scale the data to .DQ
     mat = mat * (2 ** dq)
@@ -85,7 +85,7 @@ def mat_dump_float(file_path_name, mat, dw, dq):
 
 def mat_dump_int(file_path_name, mat, dw, dq):
     if mat.ndim != 1:
-        print "Input mat dimension is not 1, will reshape to 1."
+        print("Input mat dimension is not 1, will reshape to 1.")
         mat = mat.reshape(-1)
     mat = _quantize(mat, dw, dq, False)
     

--- a/util/math2.py
+++ b/util/math2.py
@@ -12,10 +12,10 @@ def is_power(n):
     return ((n & (n - 1)) == 0) and n != 0
 
 if __name__ == '__main__':
-    print lcm(512, 3)
-    print '16:', is_power(16)
-    print '4:', is_power(4)
-    print '2:', is_power(2)
-    print '5:', is_power(5)
-    print '1:', is_power(1)
+    print(lcm(512, 3))
+    print('16:', is_power(16))
+    print('4:', is_power(4))
+    print('2:', is_power(2))
+    print('5:', is_power(5))
+    print('1:', is_power(1))
     

--- a/util/misc.py
+++ b/util/misc.py
@@ -2,7 +2,8 @@
 
 import os
 from settings import *
-import ConfigParser
+#import ConfigParser
+import configparser as ConfigParser
 
 def get_operator_name(operator_type, channel_parall_factor):
     if operator_type == 'vector_muladd':
@@ -72,7 +73,7 @@ def get_layer_cpf(layer_name, optim_file=None):
     try:
         cpf = int(cf.get(layer_name, 'CPF'))
     except:
-        print 'Layer %s:CPF is not provide in optimation configure file, will use default value 1 instead.'%layer_name
+        print('Layer %s:CPF is not provide in optimation configure file, will use default value 1 instead.'%layer_name)
         cpf = 1
     return cpf
 
@@ -84,7 +85,7 @@ def get_layer_kpf(layer_name, optim_file=None):
     try:
         kpf = int(cf.get(layer_name, 'KPF'))
     except:
-        print 'Layer %s:KPF is not provide in optimation configure file, will use default value 1 instead.'%layer_name
+        print('Layer %s:KPF is not provide in optimation configure file, will use default value 1 instead.'%layer_name)
         kpf = 1
     return kpf
 
@@ -98,7 +99,7 @@ def get_layer_dma_delay(layer_name, optim_file=None):
         if dma_delay > MAX_DDR_DMA_DELAY:
             raise Exception ('Layer %s:DMA_DELAY is too large, can not excced %d.'%(layer_name, MAX_DDR_DMA_DELAY))
     except:
-        print 'Layer %s:DMA_DELAY is not provide in optimation configure file, will use default value 0 instead.'%layer_name
+        print('Layer %s:DMA_DELAY is not provide in optimation configure file, will use default value 0 instead.'%layer_name)
         dma_delay = 0
     return dma_delay
 

--- a/util/optim.py
+++ b/util/optim.py
@@ -44,5 +44,5 @@ def optim_cpf_kpf(cpf, kpf, max_kpf):
 
 if __name__ == '__main__':
 
-    print optim_cpf_kpf(16, 2, 16)
+    print(optim_cpf_kpf(16, 2, 16))
 

--- a/util/resource.py
+++ b/util/resource.py
@@ -3,7 +3,8 @@
 import math
 from settings import *
 import chip_define
-import ConfigParser
+#import ConfigParser
+import configparser as ConfigParser
 
 width_list = [1, 2, 4, 9, 18, 36]
 depth_list = [16392, 8192, 4096, 2048, 1024, 512]
@@ -75,8 +76,8 @@ def get_ddr_bandwidth(res_file=None):
 
 if __name__ == '__main__':
     
-    print '16, 8064, 64, 2016 :', get_brams(16, 8064, 64, 2016)
-    print '512, 49, 512, 49 :', get_brams(512, 49, 512, 49)
-    print '256, 3312, 256, 3312 :', get_brams(256, 3312, 256, 3312)
-    print '256, 2310, 128,  4620:', get_brams(256, 2310, 128, 4620)
-    print '512, 600, 1024, 300 :', get_brams(512, 600, 1024, 300)
+    print('16, 8064, 64, 2016 :', get_brams(16, 8064, 64, 2016))
+    print('512, 49, 512, 49 :', get_brams(512, 49, 512, 49))
+    print('256, 3312, 256, 3312 :', get_brams(256, 3312, 256, 3312))
+    print('256, 2310, 128,  4620:', get_brams(256, 2310, 128, 4620))
+    print('512, 600, 1024, 300 :', get_brams(512, 600, 1024, 300))


### PR DESCRIPTION
Patch fix for the issue [#1](https://github.com/herald27701/AccDNN/issues/1#issue-3128110846)

## Summary by Sourcery

Make codebase Python 3 compatible by converting print statements to function calls and updating config parser imports, and update documentation with conda environment setup instructions

Enhancements:
- Convert all bare print statements to Python 3 compatible print() calls across multiple modules
- Alias the built-in configparser module as ConfigParser instead of the deprecated ConfigParser import in util and layer files

Documentation:
- Add conda environment creation commands for Python 2 and Python 3 in README
- Change caffe installation instructions to optional in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to clarify environment setup and optional dependencies.

- **Style**
  - Updated all print statements to Python 3 syntax for improved compatibility.
  - Modernized import statements for configuration parsing modules to use Python 3 standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->